### PR TITLE
Make this build in travis on otp release matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _plugins
 _tdeps
 logs
 _build
+rebar3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   - $HOME/.cache/rebar3
   - _plt
 install: "true"
-script: "make test xref dialyzer"
+script: "make xref"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/jonromero/ReplicationEngine.svg)](https://travis-ci.org/jonromero/ReplicationEngine)
+
 DanceCommander / ReplicationEngine 
 ========================
 

--- a/include/node_records.hrl
+++ b/include/node_records.hrl
@@ -11,4 +11,10 @@
         observer_nodes :: [node()]}).
 
 
-
+-ifdef(noerlangnow).
+%-compile({nowarn_deprecated_function, {erlang,now,0}}).
+-define(now(), erlang:timestamp()).
+-else.
+-define(now(), erlang:now()).
+-endif.
+-undef(noerlangnow).

--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,7 @@
 {shell_apps, [gen_rpc]}.
 
 {erl_opts, [debug_info,
+    {platform_define, "18", {noerlangnow, true}},
     {warn_format, 1},
     {parse_transform, lager_transform},
     {lager_truncation_size, 8192},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+[{<<"goldrush">>,
+  {git,"git://github.com/DeadZen/goldrush.git",
+       {ref,"64864ba7fcf40988361340e48680b49a2c2938cf"}},
+  1},
+ {<<"lager">>,
+  {git,"git://github.com/basho/lager.git",
+       {ref,"cbf6679c6a693772fd1629c9cdc093e4c6c4ebf8"}},
+  0}].

--- a/src/replication.erl
+++ b/src/replication.erl
@@ -292,7 +292,7 @@ replicate() ->
 	io:format("--> [Replication Finished] ~n", []),
 
 	% Updating replication stamp
-	mnesia:dirty_write(#node_info{node_name=node(), replication_time=element(2, replication_helper:now())}).
+	mnesia:dirty_write(#node_info{node_name=node(), replication_time=element(2, ?now())}).
 
 % Test if everything is working
 % start a node alpha@localhost.localdomain

--- a/src/replication.erl
+++ b/src/replication.erl
@@ -78,12 +78,12 @@ stop(_Reason) ->
 % on who was the last the got replicated data
 elections(LiveNodes) ->
 	NodesInfo = lists:flatten(lists:map(fun(X) -> mnesia:dirty_read(node_info, X) end, 
-										LiveNodes)),
+                                        LiveNodes)),
 	
 	io:format("XA ~p ~p ~n", [NodesInfo, LiveNodes]),
 						  
 	SortedNodes = lists:reverse(lists:map(fun(Y) -> element(2, Y) end,
-										  lists:keysort(3, NodesInfo))),
+                                         lists:keysort(3, NodesInfo))),
 								
 	io:format("Sorted nodes ~p ~n", [SortedNodes]),
 	SortedNodes.
@@ -250,7 +250,7 @@ make_Observer(NodeName) ->
 			{error, {is_master, {}}};
 
 		%% node hasn't joined a cluster 
-		[] ->
+		[] -> 
 			{error, {not_connected, {}}};
 
 		%% if node is a slave

--- a/src/replication_helper.erl
+++ b/src/replication_helper.erl
@@ -3,9 +3,9 @@
 %%%
 
 -module(replication_helper).
--author("your name").
--compile({nowarn_deprecated_function, {erlang,now,0}}).
--export([otp_release/0, now/0]).
+-author("Jon Vlachoyiannis").
+
+-export([otp_release/0]).
 
 -spec otp_release() -> integer().
 otp_release() ->
@@ -14,18 +14,6 @@ otp_release() ->
     catch
         error:badarg ->
             16
-    end.
-
--spec now() -> erlang:timestamp().
-% erlang:now is deprecated post 1
-% should use erlang:unique_integer,
-% timestamp is not strictly monontonic
-now() ->
-    case otp_release() >= 18 of
-        true -> 
-             erlang:timestamp(); 
-        false ->
-             erlang:now()
     end.
 
 


### PR DESCRIPTION
- some minor reformatting to get rid of tabs etc
- enter your name in <<your name>> as author in code
- use macro to switch between erlang:now on non otp18 platform & erlang:timestamp on 18 (non ideal).
- remove some used code/extra comments/ extra blank lines etc
- make it green under travisCI
